### PR TITLE
Use file:// schema to add the torrent file to transmission

### DIFF
--- a/trawa/tw.py
+++ b/trawa/tw.py
@@ -54,7 +54,7 @@ class TorrentWatcher:
                         server['port'],
                         server['username'],
                         server['password'],
-                        str(filename),
+                        f'file://{str(filename)}',
                         **conf_dir['rpc_params'])
                     break
 


### PR DESCRIPTION
transmissionrpc expects local files to have a "file://" schema. If we
don't use it, it passes the path to file to transmission as being on
transmission's local filesystem.

This is a must if you use trawa on a diferent server.